### PR TITLE
Append include_path with vendor directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,18 @@ This plugin lets you sync your Google Addressbook in readonly mode with Roundcub
 > git clone https://github.com/stwa/google-addressbook google_addressbook  
 > cd google_addressbook/  
 > echo "$rcmail_config['plugins'][] = 'google_addressbook';" >> ../../config/main.inc.php  
-> cd ../../
-> mkdir -p vendor/google
-> cd vendor/google/
-> curl -L "https://github.com/google/google-api-php-client/archive/1.0.4-beta.zip" -O
-> unzip 1.0.4-beta.zip 
-> mv google-api-php-client-1.0.4-beta apiclient
-
-or
-
-> Simply use Composer for installation
-> http://plugins.roundcube.net/packages/stwa/google-addressbook
-
+> cd ../../  
+> mkdir -p vendor/google  
+> cd vendor/google/  
+> curl -L "https://github.com/google/google-api-php-client/archive/1.0.4-beta.zip" -O  
+> unzip 1.0.4-beta.zip  
+> mv google-api-php-client-1.0.4-beta apiclient  
+  
+or  
+  
+> Simply use Composer for installation  
+> http://plugins.roundcube.net/packages/stwa/google-addressbook  
+  
 *Do not forget to create the database table using the SQL from SQL/*
 
 ## Command Line


### PR DESCRIPTION
It is needed to have the correct directory in the include_path variable. Otherwise the script fails to find the Google API library.
