### PR TITLE
Allow to change the Google application credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ Just specify an entry like:
 0 */4 * * * /path/to/roundcube/plugins/google_addressbook/sync-cli.sh  
 (Every 4 hours in this example)
 
+## Own Google Application
+You can register your plugin with Google to customize the application name that is presented to users when requesting access to contacts. For this, you have to register at https://console.developers.google.com/ and create a project for your roundcube installation. You get an application name, a client id and a secret. Put these values in a file named `config.inc.php` inside the `plugins/google_addressbook` folder like this:
+```
+<?php
+$config['google_addressbook_application_name'] = 'your-application-name';
+$config['google_addressbook_client_id'] = 'your-application-id';
+$config['google_addressbook_client_secret'] = 'your-application-secret';
+```
+Be aware that all existing oauth tokens will not work any more and the users have to request a new access token from Google. So you might want to do this change in a new installation only.
+
 ## Todo
 * Login autosync too slow while waiting for contacts to load
 * Add possibility to revoke tokens

--- a/google_func.php
+++ b/google_func.php
@@ -20,11 +20,12 @@ class google_func
 
   static function get_client()
   {
+    $config = rcmail::get_instance()->config;
     $client = new Google_Client();
-    $client->setApplicationName('rc-google-addressbook');
+    $client->setApplicationName($config->get('google_addressbook_application_name', 'rc-google-addressbook'));
     $client->setScopes("http://www.google.com/m8/feeds/");
-    $client->setClientId('775403024003-e5m4h02j1hsgjj0dipef3ugbg8ee9emb.apps.googleusercontent.com');
-    $client->setClientSecret('HcRLtRTEGIqScjMpkREddO6L');
+    $client->setClientId($config->get('google_addressbook_client_id', '775403024003-e5m4h02j1hsgjj0dipef3ugbg8ee9emb.apps.googleusercontent.com'));
+    $client->setClientSecret($config->get('google_addressbook_client_secret', 'HcRLtRTEGIqScjMpkREddO6L'));
     $client->setRedirectUri('urn:ietf:wg:oauth:2.0:oob');
     $client->setAccessType('offline');
     return $client;


### PR DESCRIPTION
... to customize the application name that is shown in Google dashboard and during oauth token creation.
This also helps to reduce the amount of requests for the shared appkey everyone uses :)