### PR TITLE
fixes #57 update the property visibility for for roundcube 1.5

### DIFF
--- a/google_addressbook_backend.php
+++ b/google_addressbook_backend.php
@@ -9,8 +9,8 @@
 
 class google_addressbook_backend extends rcube_contacts
 {
-  private $user_id;
-  private $db;
+  protected $user_id;
+  protected $db;
 
   function __construct($dbconn, $user)
   {


### PR DESCRIPTION
Fixes the error message caused by this plugin in roundcube 1.5

```
[05-Nov-2021 22:48:25 America/New_York] PHP Fatal error:  Access level to google_addressbook_backend::$db must be protected (as in class rcube_contacts) or weaker in /srv/roundcubemail/releases/1.5.0/plugins/google_addressbook/google_addressbook_backend.php on line 11

[05-Nov-2021 22:49:10 America/New_York] PHP Fatal error:  Access level to google_addressbook_backend::$user_id must be protected (as in class rcube_contacts) or weaker in /srv/roundcubemail/releases/1.5.0/plugins/google_addressbook/google_addressbook_backend.php on line 11

```